### PR TITLE
Refactor public interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
     -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
     -skip-testing:LstnTests/AudioEngineSpec
     -skip-testing:LstnTests/PlayerSpec
-
   - pod lib lint
 
 # deploy:

--- a/Example/Lstn.xcodeproj/project.pbxproj
+++ b/Example/Lstn.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		370835BB1DB7A04B00B26896 /* AudioEngineSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370835BA1DB7A04B00B26896 /* AudioEngineSpec.swift */; };
 		370835BD1DB7A31300B26896 /* AudioEngineSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370835BC1DB7A31300B26896 /* AudioEngineSpy.swift */; };
 		370835BF1DB7B12B00B26896 /* PopCorrupt.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 370835BE1DB7B12B00B26896 /* PopCorrupt.m4a */; };
-		371F52DF1DC230DB00DAF7AA /* ExampleObjectiveC.m in Sources */ = {isa = PBXBuildFile; fileRef = 371F52DE1DC230DB00DAF7AA /* ExampleObjectiveC.m */; };
+		371F52DF1DC230DB00DAF7AA /* ExampleObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 371F52DE1DC230DB00DAF7AA /* ExampleObjC.m */; };
 		3733573B1DB761840058ED70 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3733573A1DB761840058ED70 /* PlayerView.swift */; };
 		374C0BBA1DD32F1400BAD1E8 /* ArticleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374C0BB81DD32EF800BAD1E8 /* ArticleSpec.swift */; };
 		374C0BBD1DD3312F00BAD1E8 /* ArticleResolverSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374C0BBB1DD3310B00BAD1E8 /* ArticleResolverSpec.swift */; };
@@ -54,7 +54,7 @@
 		370835BC1DB7A31300B26896 /* AudioEngineSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioEngineSpy.swift; sourceTree = "<group>"; };
 		370835BE1DB7B12B00B26896 /* PopCorrupt.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = PopCorrupt.m4a; sourceTree = "<group>"; };
 		371F52DD1DC230DB00DAF7AA /* LstnTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LstnTests-Bridging-Header.h"; sourceTree = "<group>"; };
-		371F52DE1DC230DB00DAF7AA /* ExampleObjectiveC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleObjectiveC.m; sourceTree = "<group>"; };
+		371F52DE1DC230DB00DAF7AA /* ExampleObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleObjC.m; sourceTree = "<group>"; };
 		3733573A1DB761840058ED70 /* PlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
 		374C0BB81DD32EF800BAD1E8 /* ArticleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArticleSpec.swift; path = Article/ArticleSpec.swift; sourceTree = "<group>"; };
 		374C0BBB1DD3310B00BAD1E8 /* ArticleResolverSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArticleResolverSpec.swift; path = Article/ArticleResolverSpec.swift; sourceTree = "<group>"; };
@@ -187,7 +187,7 @@
 			children = (
 				607FACEB1AFB9204008FA782 /* Main.swift */,
 				37840D901DB6733800B92DF5 /* Example.swift */,
-				371F52DE1DC230DB00DAF7AA /* ExampleObjectiveC.m */,
+				371F52DE1DC230DB00DAF7AA /* ExampleObjC.m */,
 				37840D861DB64B5A00B92DF5 /* Audio */,
 				374C0BB71DD32EDA00BAD1E8 /* Article */,
 				37840D821DB62F9500B92DF5 /* Player */,
@@ -469,7 +469,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				371F52DF1DC230DB00DAF7AA /* ExampleObjectiveC.m in Sources */,
+				371F52DF1DC230DB00DAF7AA /* ExampleObjC.m in Sources */,
 				37840D651DB5161A00B92DF5 /* PlayerSpec.swift in Sources */,
 				3702733E1DD4B24500C8E3ED /* MockArticleResolver.swift in Sources */,
 				37840D7D1DB6216300B92DF5 /* MockURLSession.swift in Sources */,

--- a/Example/Lstn/ArticlesController.swift
+++ b/Example/Lstn/ArticlesController.swift
@@ -86,9 +86,9 @@ extension ArticlesController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 
-        let url = self.urlForRow(index: indexPath.row)
-
-        Lstn.shared.player.load(source: url) { success in
+        // TODO: Fetch articles form live source and use real IDs here
+        
+        Lstn.shared.player.load(article: "123", publisher: "456") { success in
             if success { Lstn.shared.player.play() }
         }
 

--- a/Example/Tests/Article/ArticleResolverSpec.swift
+++ b/Example/Tests/Article/ArticleResolverSpec.swift
@@ -43,7 +43,7 @@ class ArticleResolverSpec: QuickSpec {
 
                 let session = MockURLSession()
                 let resolver = RemoteArticleResolver(endpoint: self.endpoint, session: session)
-                let url = self.endpoint.appendingPathComponent("/publisher/456/articles/123/")
+                let url = self.endpoint.appendingPathComponent("/publisher/456/articles/123")
 
                 resolver.resolve(key: self.key)
 

--- a/Example/Tests/Example.swift
+++ b/Example/Tests/Example.swift
@@ -10,8 +10,10 @@ import Lstn
 
 class Example {
 
-    let player = Player()
-    let article = URL(string: "https://example.com/article.html")!
+    let player = Lstn.createPlayer()
+
+    let article = "12345-an-article-id"
+    let publisher = "12345-a-publisher-token"
 
     var loading = false
     var playing = false
@@ -23,7 +25,7 @@ class Example {
     }
 
     func loadButtonWasTapped() {
-        self.player.load(source: self.article)
+        self.player.load(article: self.article, publisher: self.publisher)
     }
 
     func playButtonWasTapped() {

--- a/Example/Tests/ExampleObjC.m
+++ b/Example/Tests/ExampleObjC.m
@@ -1,5 +1,5 @@
 //
-//  ExampleObjectiveC.m
+//  ExampleObjC.m
 //  Lstn
 //
 //  Created by Dan Halliday on 27/10/2016.
@@ -10,10 +10,12 @@
 
 @import Lstn;
 
-@interface ExampleObjectiveC : NSObject <PlayerDelegate>
+@interface ExampleObjC : NSObject <PlayerDelegate>
 
-@property Player *player;
-@property NSURL *article;
+@property (strong) id<Player> player;
+
+@property NSString *article;
+@property NSString *publisher;
 
 @property BOOL loading;
 @property BOOL playing;
@@ -22,7 +24,7 @@
 
 @end
 
-@implementation ExampleObjectiveC
+@implementation ExampleObjC
 
 - (instancetype)init {
 
@@ -30,8 +32,10 @@
 
     if (self) {
 
-        _player = [Player new];
-        _article = [[NSURL alloc] initWithString:@"https://example.com/article.html"];
+        _player = [Lstn createPlayer];
+
+        _article = @"12345-an-article-id";
+        _publisher = @"12345-a-publisher-token";
 
         _loading = false;
         _playing = false;
@@ -47,7 +51,7 @@
 }
 
 - (void)loadButtonWasTapped {
-    [_player loadWithSource:_article];
+    [_player loadWithArticle: self.article publisher:self.publisher];
 }
 
 - (void)playButtonWasTapped {

--- a/Example/Tests/Player/PlayerSpec.swift
+++ b/Example/Tests/Player/PlayerSpec.swift
@@ -8,36 +8,41 @@
 
 import Quick
 import Nimble
-import Lstn
+import Foundation
+
+@testable import Lstn
+
+private let timeout = 5.0 // TODO: Implement mock audio engine to avoid reading from disk
 
 class PlayerSpec: QuickSpec {
 
+    private let article = "article-id-string"
+    private let publisher = "publisher-token-string"
+
     override func spec() {
 
-        describe("Player") {
+        describe("Default Player") {
+
+            it("should exist") {
+                _ = DefaultPlayer.self
+            }
 
             it("should load a URL") {
-
-                let player = Player()
-                let url = URL(string: "http://example.com")!
-
-                player.load(source: url)
-
+                DefaultPlayer().load(article: self.article, publisher: self.publisher)
             }
 
             describe("callback interface") {
 
                 it("should call back after loading a URL") {
 
-                    let player = Player(resolver: SucceedingArticleResolver())
-                    let url = URL(string: "http://example.com")!
+                    let player = DefaultPlayer(resolver: SucceedingArticleResolver())
                     var result: Bool? = nil
 
-                    player.load(source: url) { success in
-                        result = success
+                    player.load(article: self.article, publisher: self.publisher) {
+                        success in result = success
                     }
 
-                    expect(result).toEventually(equal(true), timeout: 10)
+                    expect(result).toEventually(equal(true), timeout: timeout)
 
                 }
 
@@ -47,29 +52,27 @@ class PlayerSpec: QuickSpec {
 
                 it("should successfully load an article") {
 
-                    let player = Player(resolver: SucceedingArticleResolver())
-                    let url = URL(string: "http://example.com")!
+                    let player = DefaultPlayer(resolver: SucceedingArticleResolver())
                     let spy = PlayerSpy()
 
                     player.delegate = spy
-                    player.load(source: url)
+                    player.load(article: self.article, publisher: self.publisher)
 
-                    expect(spy.loadingDidStartFired).toEventually(equal(true), timeout: 10)
-                    expect(spy.loadingDidFinishFired).toEventually(equal(true), timeout: 10)
+                    expect(spy.loadingDidStartFired).toEventually(equal(true), timeout: timeout)
+                    expect(spy.loadingDidFinishFired).toEventually(equal(true), timeout: timeout)
 
                 }
 
                 it("should fail to load an article if article resolution fails") {
 
-                    let player = Player(resolver: FailingArticleResolver())
-                    let url = URL(string: "http://example.com")!
+                    let player = DefaultPlayer(resolver: FailingArticleResolver())
                     let spy = PlayerSpy()
 
                     player.delegate = spy
-                    player.load(source: url)
+                    player.load(article: self.article, publisher: self.publisher)
 
-                    expect(spy.loadingDidStartFired).toEventually(equal(true), timeout: 10)
-                    expect(spy.loadingDidFailFired).toEventually(equal(true), timeout: 10)
+                    expect(spy.loadingDidStartFired).toEventually(equal(true), timeout: timeout)
+                    expect(spy.loadingDidFailFired).toEventually(equal(true), timeout: timeout)
                     
                 }
 

--- a/Lstn/Classes/Article/Article.swift
+++ b/Lstn/Classes/Article/Article.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Article {
+struct Article {
 
     let key: ArticleKey
 
@@ -22,7 +22,7 @@ public struct Article {
 
 }
 
-public struct ArticleKey {
+struct ArticleKey {
 
     let id: String
     let publisher: String
@@ -31,7 +31,7 @@ public struct ArticleKey {
 
 extension Article: Equatable {
 
-    public static func ==(lhs: Article, rhs: Article) -> Bool {
+    static func ==(lhs: Article, rhs: Article) -> Bool {
 
         return lhs.key == rhs.key
             && lhs.source == rhs.source
@@ -47,7 +47,7 @@ extension Article: Equatable {
 
 extension ArticleKey: Equatable {
 
-    public static func ==(lhs: ArticleKey, rhs: ArticleKey) -> Bool {
+    static func ==(lhs: ArticleKey, rhs: ArticleKey) -> Bool {
 
         return lhs.id == rhs.id && lhs.publisher == rhs.publisher
 
@@ -57,7 +57,7 @@ extension ArticleKey: Equatable {
 
 extension ArticleKey: Hashable {
 
-    public var hashValue: Int {
+    var hashValue: Int {
         return "\(self.id)\(self.publisher)".hashValue
     }
 

--- a/Lstn/Classes/Article/ArticleResolver.swift
+++ b/Lstn/Classes/Article/ArticleResolver.swift
@@ -6,7 +6,7 @@
 //
 //
 
-public protocol ArticleResolver {
+protocol ArticleResolver {
 
     func resolve(key: ArticleKey)
 
@@ -14,7 +14,7 @@ public protocol ArticleResolver {
 
 }
 
-public protocol ArticleResolverDelegate: class {
+protocol ArticleResolverDelegate: class {
 
     func resolutionDidStart(key: ArticleKey)
     func resolutionDidFinish(key: ArticleKey, article: Article)

--- a/Lstn/Classes/Article/RemoteArticleResolver.swift
+++ b/Lstn/Classes/Article/RemoteArticleResolver.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public class RemoteArticleResolver: ArticleResolver {
+class RemoteArticleResolver: ArticleResolver {
 
-    public weak var delegate: ArticleResolverDelegate? = nil
+    weak var delegate: ArticleResolverDelegate? = nil
 
     private let endpoint: URL
     private let session: URLSessionType
@@ -24,12 +24,12 @@ public class RemoteArticleResolver: ArticleResolver {
 
     }
 
-    public func resolve(key: ArticleKey) {
+    func resolve(key: ArticleKey) {
 
         self.delegate?.resolutionDidStart(key: key)
 
         let url = self.endpoint
-            .appendingPathComponent("/publisher/\(key.publisher)/articles/\(key.id)/")
+            .appendingPathComponent("/publisher/\(key.publisher)/articles/\(key.id)")
 
         let task = self.session.dataTask(with: url) { data, response, error in
 

--- a/Lstn/Classes/Audio/AudioEngine.swift
+++ b/Lstn/Classes/Audio/AudioEngine.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol AudioEngine {
+protocol AudioEngine {
 
     func load(url: URL)
 
@@ -22,7 +22,7 @@ public protocol AudioEngine {
 
 }
 
-public protocol AudioEngineDelegate: class {
+protocol AudioEngineDelegate: class {
 
     func loadingDidStart()
     func loadingDidFinish()

--- a/Lstn/Classes/Lstn.swift
+++ b/Lstn/Classes/Lstn.swift
@@ -4,7 +4,7 @@ import Foundation
 
     public static let shared = Lstn()
 
-    public let player = Player()
+    public let player: Player = LocalPlayer()
 
     private override init() {
         super.init()

--- a/Lstn/Classes/Lstn.swift
+++ b/Lstn/Classes/Lstn.swift
@@ -2,15 +2,29 @@ import Foundation
 
 @objc public class Lstn: NSObject {
 
+    /// Singleton instance for easy access to Lstn.
+    ///
+    /// For more complex apps it may be desirable to use Lstn's classes directly. Factory methods
+    /// are provided for this purpose. For example, to create a player, use `Lstn.createPlayer()`.
+    ///
     public static let shared = Lstn()
 
-    public let player: Player = LocalPlayer()
+    /// Lstn's podcast player.
+    ///
+    /// The `Player` loads text articles and plays them as spoken audio using Lstn's web service.
+    ///
+    public let player: Player = DefaultPlayer()
+
+    /// Factory vending Player instances.
+    /// - Returns: A Player instance
+    ///
+    public static func createPlayer() -> Player { return DefaultPlayer() }
+
+    // static let API = URL(string: "https://api.lstn.ltd")!
+    static let API = URL(string: "https://private-378fa2-lstn.apiary-mock.com/v1")!
 
     private override init() {
         super.init()
     }
-
-    // static let API = URL(string: "https://api.lstn.ltd")!
-    static let API = URL(string: "https://private-378fa2-lstn.apiary-mock.com/v1")!
 
 }

--- a/Lstn/Classes/Player/LocalPlayer.swift
+++ b/Lstn/Classes/Player/LocalPlayer.swift
@@ -1,0 +1,221 @@
+//
+//  LocalPlayer.swift
+//  Pods
+//
+//  Created by Dan Halliday on 10/11/2016.
+//
+//
+
+import Foundation
+
+class LocalPlayer: NSObject, Player {
+
+    public weak var delegate: PlayerDelegate? = nil
+
+    fileprivate let resolver: ArticleResolver
+    fileprivate let engine: AudioEngine
+    fileprivate let control: RemoteControl
+
+    fileprivate var loadCallback: PlayerCallback?
+    fileprivate var playCallback: PlayerCallback?
+    fileprivate var stopCallback: PlayerCallback?
+
+    fileprivate let queue = DispatchQueue.main
+
+    fileprivate var article: Article? = nil
+
+    public init(resolver: ArticleResolver = RemoteArticleResolver(),
+                engine: AudioEngine = DefaultAudioEngine(),
+                control: RemoteControl = SystemRemoteControl()) {
+
+        self.resolver = resolver
+        self.engine = engine
+        self.control = control
+
+        super.init()
+
+        self.resolver.delegate = self
+        self.engine.delegate = self
+        self.control.delegate = self
+
+    }
+
+    override convenience init() {
+        // For Objective-C compatibility
+        self.init(resolver: RemoteArticleResolver(), engine: DefaultAudioEngine(), control: SystemRemoteControl())
+    }
+
+    func load(source: URL, complete: PlayerCallback? = nil) {
+
+        self.loadCallback = complete
+        self.resolver.resolve(key: ArticleKey(id: "123", publisher: "456"))
+
+    }
+
+    func play(complete: PlayerCallback? = nil) {
+
+        self.playCallback = complete
+        self.engine.play()
+
+    }
+
+    func stop(complete: PlayerCallback? = nil) {
+
+        self.stopCallback = complete
+        self.engine.stop()
+
+    }
+
+    fileprivate func dispatch(closure: @escaping () -> Void) {
+        DispatchQueue.main.async(execute: closure)
+    }
+
+    fileprivate func remoteItemForArticle(article: Article?) -> RemoteControlItem? {
+
+        guard let article = article else {
+            return nil
+        }
+
+        return RemoteControlItem(
+            title: article.title, author: article.author, publisher: article.publisher,
+            url: article.source, duration: self.engine.totalTime, image: article.image
+        )
+
+    }
+
+}
+
+extension LocalPlayer: ArticleResolverDelegate {
+
+    public func resolutionDidStart(key: ArticleKey) {
+        self.delegate?.loadingDidStart()
+    }
+
+    public func resolutionDidFinish(key: ArticleKey, article: Article) {
+
+        self.control.itemDidChange(item: self.remoteItemForArticle(article: article))
+
+        self.article = article
+        self.engine.load(url: article.audio)
+
+    }
+
+    public func resolutionDidFail(key: ArticleKey) {
+
+        self.delegate?.loadingDidFail()
+        self.loadCallback?(false)
+
+    }
+
+}
+
+extension LocalPlayer: AudioEngineDelegate {
+
+    func loadingDidStart() {
+        // ...
+    }
+
+    func loadingDidFinish() {
+
+        self.control.itemDidChange(item: self.remoteItemForArticle(article: self.article))
+
+        self.queue.async {
+            self.delegate?.loadingDidFinish()
+            self.loadCallback?(true)
+            self.loadCallback = nil
+        }
+
+    }
+
+    func loadingDidFail() {
+
+        self.queue.async {
+            self.delegate?.loadingDidFail()
+            self.loadCallback?(false)
+            self.loadCallback = nil
+        }
+
+    }
+
+    func playbackDidStart() {
+
+        self.control.playbackDidStart(position: self.engine.elapsedTime)
+
+        self.queue.async {
+            self.delegate?.playbackDidStart()
+            self.playCallback?(true)
+            self.playCallback = nil
+        }
+
+    }
+
+    func playbackDidProgress(amount: Double) {
+
+        self.queue.async {
+            self.delegate?.playbackDidProgress(amount: amount)
+        }
+
+    }
+
+    func playbackDidStop() {
+
+        self.control.playbackDidStop(position: self.engine.elapsedTime)
+
+        self.queue.async {
+            self.delegate?.playbackDidStop()
+            self.stopCallback?(true)
+            self.stopCallback = nil
+        }
+
+    }
+
+    func playbackDidFinish() {
+
+        self.queue.async {
+            self.delegate?.playbackDidFinish()
+        }
+
+    }
+
+    func playbackDidFail() {
+
+        self.queue.async {
+            self.delegate?.playbackDidFail()
+            self.playCallback?(false)
+            self.playCallback = nil
+        }
+
+    }
+
+}
+
+extension LocalPlayer: RemoteControlDelegate {
+
+    func playCommandDidFire() {
+        self.engine.play()
+    }
+
+    func pauseCommandDidFire() {
+        self.engine.stop()
+    }
+
+}
+
+// MARK: - Objective-C compatibility
+//
+//    extension LocalPlayer {
+//
+//
+//        func load(source: URL) {
+//            self.load(source: source, complete: nil)
+//        }
+//        
+//        func play() {
+//            self.play(complete: nil)
+//        }
+//        
+//        func stop() {
+//            self.stop(complete: nil)
+//        }
+//        
+//    }

--- a/Lstn/Classes/Player/Player.swift
+++ b/Lstn/Classes/Player/Player.swift
@@ -9,6 +9,23 @@
 import Foundation
 import MediaPlayer
 
+public protocol Player {
+
+//    init()
+//    init(resolver: ArticleResolver, engine: AudioEngine, control: RemoteControl)
+//    nope - no public initialiser we're going to provide a factory method.
+
+//    func load(article: String, publisher: String)
+//    func load(article: String, publisher: String, complete: PlayerCallback)
+
+//    func play()
+//    func play(complete: PlayerCallback)
+
+//    func stop()
+//    func stop(complete: PlayerCallback)
+
+}
+
 @objc public protocol PlayerDelegate: class {
 
     func loadingDidStart()
@@ -23,177 +40,4 @@ import MediaPlayer
 
 }
 
-@objc public class Player: NSObject {
-
-    public weak var delegate: PlayerDelegate? = nil
-
-    fileprivate let resolver: ArticleResolver
-    fileprivate let engine: AudioEngine
-    fileprivate let remote: Remote
-
-    public typealias Callback = (Bool) -> Void
-
-    fileprivate var loadCallback: Callback?
-
-    fileprivate let queue = DispatchQueue.main
-
-    fileprivate var article: Article? = nil
-
-    public init(resolver: ArticleResolver = RemoteArticleResolver(),
-                engine: AudioEngine = DefaultAudioEngine(),
-                remote: Remote = MediaPlayerRemote()) {
-
-        self.resolver = resolver
-        self.engine = engine
-        self.remote = remote
-
-        super.init()
-
-        self.resolver.delegate = self
-        self.engine.delegate = self
-        self.remote.delegate = self
-
-    }
-
-    override convenience init() {
-        // For Objective-C compatibility
-        self.init(resolver: RemoteArticleResolver(), engine: DefaultAudioEngine(), remote: MediaPlayerRemote())
-    }
-
-    public func load(source: URL, complete: Callback? = nil) {
-        self.loadCallback = complete
-        self.resolver.resolve(key: ArticleKey(id: "123", publisher: "456"))
-    }
-
-    public func play(complete: Callback? = nil) {
-        self.engine.play()
-        // TODO: Callback?
-    }
-
-    public func stop(complete: Callback? = nil) {
-        self.engine.stop()
-        // TODO: Callback?
-    }
-
-    fileprivate func dispatch(closure: @escaping () -> Void) {
-        DispatchQueue.main.async(execute: closure)
-    }
-
-    fileprivate func remoteItemForArticle(article: Article?) -> RemoteItem? {
-
-        guard let article = article else {
-            return nil
-        }
-
-        return RemoteItem(title: article.title, author: article.author,
-                          publisher: article.publisher, url: article.source,
-                          duration: self.engine.totalTime, image: article.image)
-
-    }
-
-}
-
-extension Player: ArticleResolverDelegate {
-
-    public func resolutionDidStart(key: ArticleKey) {
-        self.delegate?.loadingDidStart()
-    }
-
-    public func resolutionDidFinish(key: ArticleKey, article: Article) {
-        self.remote.itemDidChange(item: self.remoteItemForArticle(article: article))
-        self.article = article
-        self.engine.load(url: article.audio)
-    }
-
-    public func resolutionDidFail(key: ArticleKey) {
-        self.delegate?.loadingDidFail()
-        self.loadCallback?(false)
-    }
-
-}
-
-extension Player: AudioEngineDelegate {
-
-    public func loadingDidStart() {
-        // ...
-    }
-
-    public func loadingDidFinish() {
-        self.remote.itemDidChange(item: self.remoteItemForArticle(article: self.article))
-        self.queue.async {
-            self.delegate?.loadingDidFinish()
-            self.loadCallback?(true)
-        }
-    }
-
-    public func loadingDidFail() {
-        self.queue.async {
-            self.delegate?.loadingDidFail()
-            self.loadCallback?(false)
-        }
-    }
-
-    public func playbackDidStart() {
-        self.remote.playbackDidStart(position: self.engine.elapsedTime)
-        self.queue.async {
-            self.delegate?.playbackDidStart()
-        }
-    }
-
-    public func playbackDidProgress(amount: Double) {
-        self.queue.async {
-            self.delegate?.playbackDidProgress(amount: amount)
-        }
-    }
-
-    public func playbackDidStop() {
-        self.remote.playbackDidStop(position: self.engine.elapsedTime)
-        self.queue.async {
-            self.delegate?.playbackDidStop()
-        }
-    }
-
-    public func playbackDidFinish() {
-        self.queue.async {
-            self.delegate?.playbackDidFinish()
-        }
-    }
-
-    public func playbackDidFail() {
-        self.queue.async {
-            self.delegate?.playbackDidFail()
-        }
-    }
-
-}
-
-extension Player: RemoteDelegate {
-
-    public func playCommandDidFire() {
-        self.engine.play()
-    }
-
-    public func pauseCommandDidFire() {
-        self.engine.stop()
-    }
-
-}
-
-// MARK: - Objective-C compatibility
-
-extension Player {
-
-
-    public func load(source: URL) {
-        self.load(source: source, complete: nil)
-    }
-
-    public func play() {
-        self.play(complete: nil)
-    }
-
-    public func stop() {
-        self.stop(complete: nil)
-    }
-
-}
+public typealias PlayerCallback = (Bool) -> Void

--- a/Lstn/Classes/Player/Player.swift
+++ b/Lstn/Classes/Player/Player.swift
@@ -7,25 +7,30 @@
 //
 
 import Foundation
-import MediaPlayer
 
-public protocol Player {
+/// Lstn's podcast player.
+///
+/// The `Player` loads text articles and plays them as spoken audio using Lstn's web service.
+///
+@objc public protocol Player: class {
 
-//    init()
-//    init(resolver: ArticleResolver, engine: AudioEngine, control: RemoteControl)
-//    nope - no public initialiser we're going to provide a factory method.
+    /// A delegate which receives `Player` events
+    ///
+    weak var delegate: PlayerDelegate? { get set }
 
-//    func load(article: String, publisher: String)
-//    func load(article: String, publisher: String, complete: PlayerCallback)
+    func load(article: String, publisher: String)
+    func load(article: String, publisher: String, complete: @escaping PlayerCallback)
 
-//    func play()
-//    func play(complete: PlayerCallback)
+    func play()
+    func play(complete: @escaping PlayerCallback)
 
-//    func stop()
-//    func stop(complete: PlayerCallback)
+    func stop()
+    func stop(complete: @escaping PlayerCallback)
 
 }
 
+/// Event delegate protocol for `Player`.
+///
 @objc public protocol PlayerDelegate: class {
 
     func loadingDidStart()
@@ -40,4 +45,6 @@ public protocol Player {
 
 }
 
+/// Success/failure callback type for `Player` methods.
+///
 public typealias PlayerCallback = (Bool) -> Void

--- a/Lstn/Classes/Remote/RemoteControl.swift
+++ b/Lstn/Classes/Remote/RemoteControl.swift
@@ -1,30 +1,30 @@
 //
-//  Remote.swift
+//  RemoteControl.swift
 //  Pods
 //
 //  Created by Dan Halliday on 08/11/2016.
 //
 //
 
-public protocol Remote {
+protocol RemoteControl {
 
-    func itemDidChange(item: RemoteItem?)
+    func itemDidChange(item: RemoteControlItem?)
 
     func playbackDidStart(position: Double)
     func playbackDidStop(position: Double)
 
-    weak var delegate: RemoteDelegate? { get set }
+    weak var delegate: RemoteControlDelegate? { get set }
 
 }
 
-public protocol RemoteDelegate: class {
+protocol RemoteControlDelegate: class {
 
     func playCommandDidFire()
     func pauseCommandDidFire()
 
 }
 
-public struct RemoteItem {
+struct RemoteControlItem {
 
     let title: String
     let author: String

--- a/Lstn/Classes/Remote/SystemRemoteControl.swift
+++ b/Lstn/Classes/Remote/SystemRemoteControl.swift
@@ -26,28 +26,33 @@ class SystemRemoteControl: NSObject, RemoteControl {
     }
 
     func itemDidChange(item: RemoteControlItem?) {
+
         self.item = item
+
         self.updateNowPlayingInfo()
         self.updateImage(image: item?.image)
+
     }
 
     func playbackDidStart(position: Double) {
+
         self.playing = true
         self.position = position
+
         self.updateNowPlayingInfo()
+
     }
 
     func playbackDidStop(position: Double) {
+
         self.playing = false
         self.position = position
+
         self.updateNowPlayingInfo()
+
     }
 
-    func nowPlayingInfo() -> [String:Any] {
-
-        guard let item = self.item else {
-            return [:]
-        }
+    func nowPlayingInfo(item: RemoteControlItem) -> [String:Any] {
 
         var info: [String:Any] = [
             MPMediaItemPropertyTitle: item.title,
@@ -70,7 +75,13 @@ class SystemRemoteControl: NSObject, RemoteControl {
     }
 
     func updateNowPlayingInfo() {
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo()
+
+        guard let item = self.item else {
+            return
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo(item: item)
+
     }
 
     func registerForCommands() {

--- a/Lstn/Classes/Remote/SystemRemoteControl.swift
+++ b/Lstn/Classes/Remote/SystemRemoteControl.swift
@@ -1,31 +1,31 @@
 //
-//  MediaPlayerRemote.swift
+//  SystemRemoteControl.swift
 //  Pods
 //
-//  Created by Dan Halliday on 08/11/2016.
+//  Created by Dan Halliday on 10/11/2016.
 //
 //
 
-import MediaPlayer
 import UIKit
+import MediaPlayer
 
-class MediaPlayerRemote: NSObject, Remote {
+class SystemRemoteControl: NSObject, RemoteControl {
 
-    var item: RemoteItem? = nil
+    var item: RemoteControlItem? = nil
 
     var playing: Bool = false
     var position: Double = 0
 
     var artwork: MPMediaItemArtwork? = nil
 
-    weak var delegate: RemoteDelegate? = nil
+    weak var delegate: RemoteControlDelegate? = nil
 
     override init() {
         super.init()
         self.registerForCommands()
     }
 
-    func itemDidChange(item: RemoteItem?) {
+    func itemDidChange(item: RemoteControlItem?) {
         self.item = item
         self.updateNowPlayingInfo()
         self.updateImage(image: item?.image)
@@ -66,7 +66,7 @@ class MediaPlayerRemote: NSObject, Remote {
         }
 
         return info
-        
+
     }
 
     func updateNowPlayingInfo() {
@@ -112,7 +112,7 @@ class MediaPlayerRemote: NSObject, Remote {
 
 // MARK: - Remote Command Handlers
 
-extension MediaPlayerRemote {
+extension SystemRemoteControl {
 
     @objc func playCommandDidFire() {
         self.delegate?.playCommandDidFire()
@@ -126,23 +126,21 @@ extension MediaPlayerRemote {
     @objc func stopCommandDidFire() {
 
     }
-
+    
     @objc func playPauseToggleCommandDidFire() {
-
+        
     }
-
+    
     @objc func previousCommandDidFire() {
-
+        
     }
-
+    
     @objc func nextCommandDidFire() {
-
+        
     }
-
+    
     @objc func changePlaybackRateCommandDidFire() {
-
+        
     }
-
-
 
 }


### PR DESCRIPTION
Public interface API surface reduced to the essential `Player` class and nothing else. Player now loads using an article ID and a publisher ID as per latest API.